### PR TITLE
Remove typing from class properties, as not allowed in php 7.3

### DIFF
--- a/Plugin/Bypass2FAAdmin.php
+++ b/Plugin/Bypass2FAAdmin.php
@@ -14,7 +14,7 @@ class Bypass2FAAdmin
     /**
      * @var Data
      */
-    protected Data $data;
+    protected $data;
 
     /**
      * BypassTwoFactorAuth constructor.

--- a/Plugin/Bypass2FAWebApi.php
+++ b/Plugin/Bypass2FAWebApi.php
@@ -19,11 +19,11 @@ class Bypass2FAWebApi
     /**
      * @var Data
      */
-    protected Data $data;
+    protected $data;
     /**
      * @var AdminTokenServiceInterface
      */
-    protected AdminTokenServiceInterface $adminTokenService;
+    protected $adminTokenService;
 
     public function __construct(
         Data $data,


### PR DESCRIPTION
Version 1 specifies a php requirement of `^7.3`, but uses typed class properties.
These were only introduced in 7.4, so need to be removed for backwards-compatibility.