### PR TITLE
Change license name to match SPDX version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "magento/module-two-factor-auth": "1.1.*"
   },
   "license": [
-    "Massachusetts Institute of Technology License (MITL)"
+    "MIT License"
   ],
   "autoload": {
     "files": [


### PR DESCRIPTION
License name not matching prevents packagist from automatically updating the package.