### PR TITLE
BEG-68 Bypass 2FA for Magento API for spesific Admin users

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -14,13 +14,32 @@ use Magento\Framework\UrlInterface;
 class Data
 {
     public const XML_PATH_ALLOWED_BYPASS_HOSTNAMES = 'bypass_2fa/settings/allowed_hostnames';
+    public const XML_PATH_ALLOWED_BYPASS_USERNAMES = 'bypass_2fa/settings/allowed_usernames';
     public const ENV_VARIABLE_BYPASS_2FA_ADMIN = 'BYPASS_2FA_ADMIN';
     public const ENV_VARIABLE_BYPASS_2FA_API = 'BYPASS_2FA_API';
 
+    /**
+     * @var DeploymentConfig
+     */
     private DeploymentConfig $deploymentConfig;
+
+    /**
+     * @var ScopeConfigInterface
+     */
     private ScopeConfigInterface $scopeConfigInterface;
+
+    /**
+     * @var UrlInterface
+     */
     private UrlInterface $url;
 
+    /**
+     * Constructor
+     *
+     * @param DeploymentConfig $deploymentConfig
+     * @param ScopeConfigInterface $scopeConfigInterface
+     * @param UrlInterface $url
+     */
     public function __construct(
         DeploymentConfig $deploymentConfig,
         ScopeConfigInterface $scopeConfigInterface,
@@ -32,7 +51,9 @@ class Data
     }
 
     /**
-     * @return bool Indicates if 2FA can be bypassed for admin access
+     * Indicates if 2FA can be bypassed for admin access
+     *
+     * @return bool
      */
     public function getBypassAdmin(): bool
     {
@@ -40,7 +61,9 @@ class Data
     }
 
     /**
-     * @return bool Indicates if 2FA can be bypassed for API token generation
+     * Indicates if 2FA can be bypassed for API token generation
+     *
+     * @return bool
      */
     public function getBypassAPI(): bool
     {
@@ -48,7 +71,34 @@ class Data
     }
 
     /**
+     * Validate the usernames that can be bypassed
+     *
+     * @param string $userName
+     * @return bool
+     */
+    public function isAllowedBypassAPiByUsername(string $userName): bool
+    {
+        $allowedUsernames = $this->getAllowedBypassUsernames();
+        return in_array($userName, $allowedUsernames);
+    }
+
+    /**
+     * Returns array of admin usernames that can be bypass
+     *
+     * @return String[]
+     */
+    private function getAllowedBypassUsernames(): array
+    {
+        $allowedUsernames = $this->scopeConfigInterface->getValue(self::XML_PATH_ALLOWED_BYPASS_USERNAMES);
+        if (empty($allowedUsernames)) {
+            $allowedUsernames = [];
+        }
+        return $allowedUsernames;
+    }
+
+    /**
      * Returns array of (partial) hostnames that can be bypassed
+     *
      * @return String[]
      */
     private function getAllowedBypassHostnames(): array
@@ -61,19 +111,22 @@ class Data
     }
 
     /**
+     * Get Environment Variable
+     *
      * @param string $environmentVariable
      * @return bool
      */
     private function getEnvironmentVariable(string $environmentVariable): bool
     {
-        if (array_key_exists($environmentVariable, $_ENV)) {
-            return $_ENV[$environmentVariable] == 1;
+        if (array_key_exists($environmentVariable, $_ENV)) { // phpcs:ignore
+            return $_ENV[$environmentVariable] == 1; // phpcs:ignore
         }
         return false;
     }
 
     /**
      * Checks if 2FA authentication can be bypassed based on environment and hostname
+     *
      * @param string $environmentVariable
      * @return bool
      */
@@ -92,6 +145,11 @@ class Data
         }
     }
 
+    /**
+     * Validate current hostname with allowed list
+     *
+     * @return bool
+     */
     private function validateCurrentHostname(): bool
     {
         // check that current base url is configured as an allowed hostname

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -76,7 +76,7 @@ class Data
      * @param string $userName
      * @return bool
      */
-    public function isAllowedBypassAPiByUsername(string $userName): bool
+    public function isAllowedBypassAPIByUsername(string $userName): bool
     {
         $allowedUsernames = $this->getAllowedBypassUsernames();
         return in_array($userName, $allowedUsernames);

--- a/Plugin/Bypass2FAWebApi.php
+++ b/Plugin/Bypass2FAWebApi.php
@@ -60,7 +60,7 @@ class Bypass2FAWebApi
         $username,
         $password
     ): string {
-        return $this->data->isAllowedBypassAPiByUsername($username) || $this->data->getBypassAPI() ?
+        return $this->data->isAllowedBypassAPIByUsername($username) || $this->data->getBypassAPI() ?
             $this->adminTokenService->createAdminAccessToken($username, $password) :
             $proceed($username, $password);
     }

--- a/Plugin/Bypass2FAWebApi.php
+++ b/Plugin/Bypass2FAWebApi.php
@@ -18,9 +18,22 @@ use Magento\TwoFactorAuth\Model\AdminAccessTokenService;
 class Bypass2FAWebApi
 {
 
+    /**
+     * @var Data
+     */
     private Data $data;
+
+    /**
+     * @var AdminTokenServiceInterface
+     */
     private AdminTokenServiceInterface $adminTokenService;
 
+    /**
+     * Constructor
+     *
+     * @param Data $data
+     * @param AdminTokenServiceInterface $adminTokenService
+     */
     public function __construct(
         Data $data,
         AdminTokenServiceInterface $adminTokenService
@@ -47,7 +60,7 @@ class Bypass2FAWebApi
         $username,
         $password
     ): string {
-        return $this->data->getBypassAPI() ?
+        return $this->data->isAllowedBypassAPiByUsername($username) || $this->data->getBypassAPI() ?
             $this->adminTokenService->createAdminAccessToken($username, $password) :
             $proceed($username, $password);
     }

--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ The `app/etc/config.php` file must have the following config setting added under
     'bypass_2fa' => [
       'settings' => [
         'allowed_hostnames' => [
-          'hostname1',
-          'hostname2',
+            'hostname1',
+            'hostname2',
           ...
+        ],
+         'allowed_usernames' => [
+            'username1',
+            'username2'
         ]
       ]
     ]
@@ -32,7 +36,7 @@ By committing this setting to the codebase, it prevents someone from overriding 
 ### Magento Cloud
 Magento Cloud environment-specific variables can be used to switch this feature on and off on a per cloud instance, especially 
 useful for integration environments where emails may not be configured.  First make sure that you've added 
-the hostname to `config.php` in the `allowed_hostnames` section, and then in the Cloud dashboard:
+the hostname to `config.php` in the `allowed_hostnames` section, and then also check you've added the usernames in the `allowed_usernames` section that need to be bypassed 2FA when generating the admin tokens. and then in the Cloud dashboard:
 
 1. Click `Configure enviroment` and enter the `Variables` tab
 2. Add `env:BYPASS_2FA_ADMIN` and `env:BYPASS_2FA_API` as needed, setting the value to 1 to enable bypass 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ By committing this setting to the codebase, it prevents someone from overriding 
 ### Magento Cloud
 Magento Cloud environment-specific variables can be used to switch this feature on and off on a per cloud instance, especially 
 useful for integration environments where emails may not be configured.  First make sure that you've added 
-the hostname to `config.php` in the `allowed_hostnames` section, and then also check you've added the usernames in the `allowed_usernames` section that need to be bypassed 2FA when generating the admin tokens. and then in the Cloud dashboard:
+the hostname to `config.php` in the `allowed_hostnames` section, and then also check you've added the usernames in the `allowed_usernames` section that need to be bypassed 2FA when generating the admin tokens.
+Then, in the Cloud dashboard:
 
 1. Click `Configure enviroment` and enter the `Variables` tab
 2. Add `env:BYPASS_2FA_ADMIN` and `env:BYPASS_2FA_API` as needed, setting the value to 1 to enable bypass 


### PR DESCRIPTION
Add the "allowed_usernames" config to specify admin user names to bypass 2FA when the admin token generating with the old method