### PR TITLE
Fix release workflow and make test workflow only run on PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Create release notes
+        id: create-release-notes
+        uses: johnyherangi/create-release-notes@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -23,7 +29,7 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
-          body_path: RELEASE_NOTES.md
+          body: ${{ steps.create-release-notes.outputs.release-notes }}
 
       - name: Update Packagist
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 on:
-  push
+  pull_request
 
 jobs:
   code-standards:


### PR DESCRIPTION
Release workflow was failing due to no release notes file existing. This automates the notes creation.